### PR TITLE
update system requirements for runit-man

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,6 +1,6 @@
 ## Requirements
 
-You need ruby 1.8.6 or above and rubygems installed.
+You need ruby 1.9.3 or above and rubygems installed.
 
 ## Installation
 


### PR DESCRIPTION
i18n depends on ruby >= 1.9.3 and therefore it bumps the dependency for runit-man.
I've just verified installation doesn't proceed on Ubuntu 12.04 with ruby 1.8 installed
